### PR TITLE
feat: Check image metadata before build

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,6 +27,9 @@ func main() { //nolint:funlen
 	flag.Var(&application.GitlabBranchRegistry, "gitlab-branch-registry", "registry to use when no tag is found in gitlab")
 	flag.Var(&application.GitlabBranchPlatform, "gitlab-branch-platform", "platform to use when no tag is found in gitlab")
 
+	flag.BoolVar(&application.CheckImageAnnotation, "check-image-annotation", true, "check image annotation")
+	flag.StringVar(&application.CheckImageAnnotationKey, "check-image-annotation-key", "org.opencontainers.image.revision", "check image annotation key")
+
 	flag.Var(&application.Tag, "tag", "tag to use")
 
 	version := flag.Bool("version", false, "print version")


### PR DESCRIPTION
This change will add annotations to all images that build with this tool - for example:
```json
"com.gitlab.ci.commit.ref.name": "test"
"com.gitlab.ci.commit.sha": "65d256156fdecbc2a1e8bf4ea3da5b7f6etest"
"com.gitlab.ci.job.id": "1664413"
"com.gitlab.ci.job.url": "https://git.test/ada/test/-/jobs/1664413"
"com.gitlab.ci.pipeline.id": "239598"
"com.gitlab.ci.pipeline.url": "https://git.test/ada/test/-/pipelines/239598"
"com.gitlab.ci.project.path": "ada/test"
"com.gitlab.ci.user.name": "test.deploy"
"org.opencontainers.image.created": "2025-02-28T13:58:41Z"
"org.opencontainers.image.revision": "65d256156fdecbc2a1e8bf4ea3da5b7f6etest"
"org.opencontainers.image.source": "https://git.test/ada/test"
```
This annotation needs to ignore image building if the current image annotation (org.opencontainers.image.revision) is the same as the remote one. This means that the image has already been built and already pushed. Add new args to control this:
```bash
# you can disable this check
--check-image-annotation=true

# you can check another image annotation
--check-image-annotation-key=org.opencontainers.image.revision
```