### PR TITLE
feat: Use zstd as default compressor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-image=paskalmaksim/parallel-image-build:dev
+image=paskalmaksim/parallel-image-build:$(shell git rev-parse --short HEAD)
 
 test:
 	go mod tidy

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,16 +27,21 @@ func main() { //nolint:funlen
 	flag.Var(&application.GitlabBranchRegistry, "gitlab-branch-registry", "registry to use when no tag is found in gitlab")
 	flag.Var(&application.GitlabBranchPlatform, "gitlab-branch-platform", "platform to use when no tag is found in gitlab")
 
-	flag.BoolVar(&application.CheckImageAnnotation, "check-image-annotation", true, "check image annotation")
-	flag.StringVar(&application.CheckImageAnnotationKey, "check-image-annotation-key", "org.opencontainers.image.revision", "check image annotation key")
+	flag.StringVar(&application.Output, "output", application.Output, "overwrite build output")
+
+	flag.BoolVar(&application.CheckImageAnnotation, "check-image-annotation", application.CheckImageAnnotation, "check image annotation")
+	flag.StringVar(&application.CheckImageAnnotationKey, "check-image-annotation-key", application.CheckImageAnnotationKey, "check image annotation key")
+
+	flag.StringVar(&application.Compression, "compression", application.Compression, "compression algorithm")
+	flag.IntVar(&application.CompressionLevel, "compression-level", application.CompressionLevel, "compression level")
+	flag.BoolVar(&application.CompressionForce, "force-compression", application.CompressionForce, "force compression")
 
 	flag.Var(&application.Tag, "tag", "tag to use")
 
 	version := flag.Bool("version", false, "print version")
 	debug := flag.Bool("debug", false, "debug mode")
 
-	// Attestation will work only with registry > v3.0.0+
-	withAttestation := flag.Bool("with-attestation", false, "publish attestation on build")
+	flag.BoolVar(&application.WithAttestation, "with-attestation", application.WithAttestation, "publish attestation on build")
 
 	flag.Parse()
 
@@ -48,8 +53,6 @@ func main() { //nolint:funlen
 	if *debug {
 		slog.SetLogLoggerLevel(slog.LevelDebug)
 	}
-
-	application.WithAttestation = *withAttestation
 
 	if err := application.Validate(); err != nil {
 		slog.Error("Error validating", "error", err.Error())

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -21,6 +21,16 @@ var Version = "dev" //nolint:gochecknoglobals
 func NewApplication() *Application {
 	return &Application{
 		ImageMetadata: types.NewImageMetadata(),
+
+		// Attestation will work only with registry > v3.0.0+
+		WithAttestation: false,
+
+		CheckImageAnnotation:    true,
+		CheckImageAnnotationKey: "org.opencontainers.image.revision",
+
+		Compression:      "zstd",
+		CompressionLevel: 3, //nolint:mnd
+		CompressionForce: true,
 	}
 }
 
@@ -41,6 +51,52 @@ type Application struct {
 
 	CheckImageAnnotation    bool
 	CheckImageAnnotationKey string
+
+	Compression      string
+	CompressionLevel int
+	CompressionForce bool
+
+	// https://docs.docker.com/build/exporters/image-registry
+	Output string
+}
+
+func (a *Application) mergeOutput() string {
+	output := make(map[string]string)
+
+	// default buildx output
+	output["type"] = "image"
+	output["oci-mediatypes"] = "true"
+
+	// compression
+	output["compression"] = a.Compression
+	if a.CompressionLevel > -1 {
+		output["compression-level"] = strconv.Itoa(a.CompressionLevel)
+	}
+
+	output["force-compression"] = strconv.FormatBool(a.CompressionForce)
+
+	const parts = 2
+
+	// append user output parameters
+	for _, param := range strings.Split(a.Output, ",") {
+		a := strings.SplitN(param, "=", parts)
+
+		if len(a) != parts {
+			slog.Warn("Invalid output parameter", "param", param)
+
+			continue
+		}
+
+		output[a[0]] = a[1]
+	}
+
+	result := []string{}
+
+	for key, value := range output {
+		result = append(result, key+"="+value)
+	}
+
+	return strings.Join(result, ",")
 }
 
 func (a *Application) shell(ctx context.Context, name string, arg ...string) error {
@@ -131,6 +187,7 @@ func (a *Application) buildImageArch(ctx context.Context, i int, platform types.
 	args := []string{
 		"--platform=" + platform.String(),
 		"--file=" + a.ImageDockerfile[i],
+		"--output=" + a.Output,
 		a.ImageContext[i],
 	}
 
@@ -322,7 +379,7 @@ func (a *Application) loadFromEnv() {
 	fromEnv("PARALLEL_IMAGE_BUILD_CHECK_IMAGE_ANNOTATION_KEY", &a.CheckImageAnnotationKey)
 }
 
-func (a *Application) Normalize() error { //nolint:cyclop
+func (a *Application) Normalize() error { //nolint:cyclop,funlen
 	a.loadFromEnv()
 
 	if len(a.Provider) == 0 {
@@ -382,6 +439,8 @@ func (a *Application) Normalize() error { //nolint:cyclop
 			return errors.Wrap(err, "failed to set registry from gitlab")
 		}
 	}
+
+	a.Output = a.mergeOutput()
 
 	return nil
 }


### PR DESCRIPTION
This pull request introduces configurable options for image output format and compression, providing users with more control over how container images are built. It adds new command-line flags for output format and compression settings, sets sensible defaults, and refactors the build process to use these options dynamically.

**New image output and compression configuration:**

* Added new fields to the `Application` struct: `Output`, `Compression`, `CompressionLevel`, and `CompressionForce`, allowing users to specify the output format and compression settings for image builds. Default values are set for each in `NewApplication()`. [[1]](diffhunk://#diff-67213f39b84a013e7db04664cd3ad943b7a237d97b9c6e862d10806ac27def28R60-R65) [[2]](diffhunk://#diff-67213f39b84a013e7db04664cd3ad943b7a237d97b9c6e862d10806ac27def28R24-R39)
* Added corresponding command-line flags in `cmd/main.go` for the new configuration options, enabling users to override defaults at runtime.

**Build process improvements:**

* Introduced the `getBuildOutput()` method to assemble the output configuration string, combining user-specified and default options for output format and compression.
* Updated the image build process to use the new output configuration by passing the result of `getBuildOutput()` as the `--output` argument to the image builder.