### PR TITLE
feat: Add output args

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,6 +26,8 @@ func main() { //nolint:funlen
 	flag.Var(&application.ImageArgs, "image-args", "args passed to docker build")
 	flag.Var(&application.GitlabBranchRegistry, "gitlab-branch-registry", "registry to use when no tag is found in gitlab")
 	flag.Var(&application.GitlabBranchPlatform, "gitlab-branch-platform", "platform to use when no tag is found in gitlab")
+	flag.Var(&application.BuildArgs, "build-arg", "arguments for build")
+	flag.Var(&application.BuildSecrets, "secret", "secrets for build")
 
 	flag.StringVar(&application.Output, "output", application.Output, "overwrite build output")
 

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -58,6 +58,9 @@ type Application struct {
 
 	// https://docs.docker.com/build/exporters/image-registry
 	Output string
+
+	BuildArgs    types.FlagList
+	BuildSecrets types.FlagList
 }
 
 func (a *Application) mergeOutput() string {
@@ -177,6 +180,20 @@ func (a *Application) ignoreBuild(ctx context.Context, tag string) bool {
 	return current == remote && remote != ""
 }
 
+func (a *Application) buildArgs() []string {
+	args := []string{}
+
+	for _, buildArg := range a.BuildArgs {
+		args = append(args, "--build-arg="+buildArg)
+	}
+
+	for _, buildSecret := range a.BuildSecrets {
+		args = append(args, "--secret="+buildSecret)
+	}
+
+	return args
+}
+
 func (a *Application) buildImageArch(ctx context.Context, i int, platform types.Platform) error {
 	image := a.ImagePath[i] + "-" + platform.Arch
 
@@ -194,6 +211,9 @@ func (a *Application) buildImageArch(ctx context.Context, i int, platform types.
 	if len(a.ImageArgs[i]) > 0 {
 		args = append(args, a.ImageArgs[i])
 	}
+
+	// add build args
+	args = append(args, a.buildArgs()...)
 
 	// add build annotations
 	args = append(args, a.ImageMetadata.GetBuildAnnotations()...)


### PR DESCRIPTION
This pull request adds support for passing custom build arguments and secrets to the build process via new command-line flags. These enhancements make it easier to customize Docker builds with additional parameters and secrets.

**Build argument and secret support:**

* Added new command-line flags `--build-arg` and `--secret` in `cmd/main.go` to allow users to specify build arguments and secrets for the Docker build process.
* Extended the `Application` struct in `internal/internal.go` to include `BuildArgs` and `BuildSecrets` fields for storing these new parameters.
* Introduced a new `buildArgs()` method in `internal/internal.go` that assembles the build arguments and secrets into the correct CLI format for use in the build command.
* Updated the `buildImageArch` function to include these build arguments and secrets when constructing the build command.